### PR TITLE
Adds rake task video_position to update video positions that are 0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,14 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+desc "take any videos with position of 0 and give them incrementing positions"
+task video_positions: :environment do
+  videos = Video.where(position: 0)
+  count = videos.count
+  videos.each do |video|
+    tutorial = video.tutorial
+    max_position = tutorial.videos.max_by{|video| video.position}.position
+    video.update(position: max_position + 1 )
+  end
+  puts "#{count} videos updated!"
+end

--- a/lib/tasks/youtube_seed.rake
+++ b/lib/tasks/youtube_seed.rake
@@ -1,13 +1,13 @@
 namespace :import do
-  desc:"All youtube data"
+  desc "All youtube data"
   task all: [:users, :tutorials, :videos]
 
-  desc:"Create Users"
+  desc "Create Users"
   task :users, [:users] => :environment do
     User.create(email: "admin@example.com", first_name: "Admin", last_name: "Adminington", password: ENV['ADMIN_PASSWORD'], role: 1)
   end
 
-  desc:"Create Tutorials"
+  desc "Create Tutorials"
   task :tutorials, [:tutorials] => :environment do
     response = Faraday.get("https://www.googleapis.com/youtube/v3/playlists?key=#{ENV['YOUTUBE_API_KEY']}&part=snippet&channelId=UC2zYYOtckevoWTGDu5SdCkg&maxResults=50")
     data = JSON.parse(response.body, symbolize_names: true)
@@ -20,7 +20,7 @@ namespace :import do
     end
   end
 
-  desc:"Create Videos"
+  desc "Create Videos"
   task :videos, [:videos] => :environment do
     tutorials = Tutorial.all
     tutorials.each do |tutorial|

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Video do
+  describe 'relationships' do
+    it { should have_many(:user_videos) }
+    it { should have_many(:users).through(:user_videos) }
+    it { should belong_to(:tutorial) }
+  end
+end


### PR DESCRIPTION
This is for card Add validation on position to video model
The instructions for this where clarified to be the following: 
"Though the default is 0, we should write a rake task to make it so there aren’t any 0 values in the database, but rather incremented behind the existing values. To give an example, if a tutorial has videos with positions of 0,0,0, 1,3,4, our rake task would update the videos with positions of 0 to 5,6,7 so all positions would now be 1,3,4,5,6,7"

Adds rake task video_positions.
Tested and validated using rails console
Paired commit (Anna & Maddie)

Co-authored-by: Anna Smolentzov <6686861+asmolentzov@users.noreply.github.com>